### PR TITLE
Update to colors.hpp bugs fixed and optimizations 

### DIFF
--- a/src/colors.hpp
+++ b/src/colors.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef CPP_COLORS_HPP
+#define CPP_COLORS_HPP
 #include <string>
 #include <iostream>
 
@@ -8,85 +10,86 @@
   3. Ends with m character
 */
 
-/// @brief A collection of ANSI escape code to control foreground colors.
-namespace fore {
-  const std::string black = "\033[30m";
-  const std::string red = "\033[31m";
-  const std::string green = "\033[32m";
-  const std::string yellow = "\033[33m";
-  const std::string blue = "\033[34m";
-  const std::string magenta = "\033[35m";
-  const std::string cyan = "\033[36m";
-  const std::string white = "\033[37m";
+namespace cpp_colors
+{
 
-  const std::string bright_black = "\033[90m";
-  const std::string bright_red = "\033[91m";
-  const std::string bright_green = "\033[92m";
-  const std::string bright_yellow = "\033[93m";
-  const std::string bright_blue = "\033[94m";
-  const std::string bright_magenta = "\033[95m";
-  const std::string bright_cyan = "\033[96m";
-  const std::string bright_white = "\033[97m";
+  /// @brief A collection of ANSI escape code to control foreground colors.
+  namespace foreground {
+    constexpr std::string_view black = "\033[30m";
+    constexpr std::string_view red = "\033[31m";
+    constexpr std::string_view green = "\033[32m";
+    constexpr std::string_view yellow = "\033[33m";
+    constexpr std::string_view blue = "\033[34m";
+    constexpr std::string_view magenta = "\033[35m";
+    constexpr std::string_view cyan = "\033[36m";
+    constexpr std::string_view white = "\033[37m";
 
-  /// @brief An alias for fore::bright_black.
-  const std::string& gray = bright_black;
+    constexpr std::string_view gray = "\033[90m";
+    constexpr std::string_view bright_red = "\033[91m";
+    constexpr std::string_view bright_green = "\033[92m";
+    constexpr std::string_view bright_yellow = "\033[93m";
+    constexpr std::string_view bright_blue = "\033[94m";
+    constexpr std::string_view bright_magenta = "\033[95m";
+    constexpr std::string_view bright_cyan = "\033[96m";
+    constexpr std::string_view bright_white = "\033[97m";
+  }
+
+  /// @brief A collection of ANSI escape code to control background colors.
+  namespace background {
+    constexpr std::string_view black = "\033[40m";
+    constexpr std::string_view red = "\033[41m";
+    constexpr std::string_view green = "\033[42m";
+    constexpr std::string_view yellow = "\033[43m";
+    constexpr std::string_view blue = "\033[44m";
+    constexpr std::string_view magenta = "\033[45m";
+    constexpr std::string_view cyan = "\033[46m";
+    constexpr std::string_view white = "\033[47m";
+
+    constexpr std::string_view gray = "\033[100m";
+    constexpr std::string_view bright_red = "\033[101m";
+    constexpr std::string_view bright_green = "\033[102m";
+    constexpr std::string_view bright_yellow = "\033[103m";
+    constexpr std::string_view bright_blue = "\033[104m";
+    constexpr std::string_view bright_magenta = "\033[105m";
+    constexpr std::string_view bright_cyan = "\033[106m";
+    constexpr std::string_view bright_white = "\033[107m";
+  }
+
+  /// @brief A collection of ANSI escape code to apply styles to output text.
+  namespace style {
+    constexpr std::string_view reset = "\033[0m";
+    constexpr std::string_view bold = "\033[1m";
+    constexpr std::string_view dim = "\033[2m";
+    constexpr std::string_view normal = "\033[22m";
+    constexpr std::string_view italic = "\033[3m";
+    constexpr std::string_view strikethrough = "\033[9m";
+    constexpr std::string_view underline = "\033[4m";
+
+    /// @brief An alias for style::bold.
+    constexpr std::string_view b = bold;
+
+    /// @brief An alias for style::italic.
+    constexpr std::string_view i = italic;
+
+    /// @brief An alias for style::underline.
+    constexpr std::string_view u = underline;
+
+    /// @brief An alias for style::strikethrough.
+    constexpr std::string_view st = strikethrough;
+  }
+
+  /// @brief Prints out a text with a style (color, bold...)
+  /// @param text is the message to be displayed.
+  /// @param color is an ANSI escape/color code. (Default is style::normal)
+  /// @param eol is an end of line character. (Default is \\n)
+  inline void colorful_print(
+    const std::string& text,
+    const std::string_view& color = style::normal,
+    std::ostream& streamline = std::cout,
+    const char eol = '\n'
+  ) {
+    streamline << color << text << style::reset << eol;
+  }
 }
 
-/// @brief A collection of ANSI escape code to control background colors.
-namespace back {
-  const std::string black = "\033[40m";
-  const std::string red = "\033[41m";
-  const std::string green = "\033[42m";
-  const std::string yellow = "\033[43m";
-  const std::string blue = "\033[44m";
-  const std::string magenta = "\033[45m";
-  const std::string cyan = "\033[46m";
-  const std::string white = "\033[47m";
-
-  const std::string bright_black = "\033[100m";
-  const std::string bright_red = "\033[101m";
-  const std::string bright_green = "\033[102m";
-  const std::string bright_yellow = "\033[103m";
-  const std::string bright_blue = "\033[104m";
-  const std::string bright_magenta = "\033[105m";
-  const std::string bright_cyan = "\033[106m";
-  const std::string bright_white = "\033[107m";
-
-  /// @brief An alias for back::bright_black.
-  const std::string& gray = bright_black;
-}
-
-/// @brief A collection of ANSI escape code to apply styles to output text.
-namespace style {
-  const std::string reset = "\033[0m";
-  const std::string bold = "\033[1m";
-  const std::string dim = "\033[2m";
-  const std::string italic = "\033[3m";
-  const std::string underline = "\033[4m";
-  const std::string strikethrough = "\033[9m";
-  const std::string normal = "\033[22m";
-
-  /// @brief An alias for style::bold.
-  const std::string& b = bold;
-
-  /// @brief An alias for style::italic.
-  const std::string& i = italic;
-
-  /// @brief An alias for style::underline.
-  const std::string& u = underline;
-
-  /// @brief An alias for style::strikethrough.
-  const std::string& st = strikethrough;
-}
-
-/// @brief Prints out a text with a style (color, bold...)
-/// @param text is the message to be displayed.
-/// @param color is an ANSI escape/color code. (Default is style::normal)
-/// @param eol is an end of line character. (Default is \\n)
-void print(
-  const std::string text,
-  const std::string& color = style::normal,
-  const char eol = '\n'
-) {
-  std::cout << color << text << style::reset << eol;
-}
+#endif


### PR DESCRIPTION
Added namespace to the whole file
Changed the print function name to more accurate name  

Optimizations: 
Optimized all the strings from string to std::string_view do disable unneeded string runtime optimization moved all the defines to constexpr for compile-time constant 
Added to print function support to change the Ostream (Default still std::cout)

Bug fixes:
Added define Compile protection
Changed the Function to inline function to fix multiple definition bug
Changed the alias from reference to constexpr to fix multiple definition  